### PR TITLE
Fix php max_input_vars settings

### DIFF
--- a/5/debian-10/rootfs/opt/bitnami/scripts/libphp.sh
+++ b/5/debian-10/rootfs/opt/bitnami/scripts/libphp.sh
@@ -58,7 +58,7 @@ php_initialize() {
     info "Configuring PHP options"
     ! is_empty_value "$PHP_MAX_EXECUTION_TIME" && info "Setting PHP max_execution_time option" && php_conf_set max_execution_time "$PHP_MAX_EXECUTION_TIME"
     ! is_empty_value "$PHP_MAX_INPUT_TIME" && info "Setting PHP max_input_time option" && php_conf_set max_input_time "$PHP_MAX_INPUT_TIME"
-    ! is_empty_value "$PHP_MAX_INPUT_VARS" && info "Setting PHP max_input_vars option" && php_conf_set max_input_time "$PHP_MAX_INPUT_VARS"
+    ! is_empty_value "$PHP_MAX_INPUT_VARS" && info "Setting PHP max_input_vars option" && php_conf_set max_input_vars "$PHP_MAX_INPUT_VARS"
     ! is_empty_value "$PHP_MEMORY_LIMIT" && info "Setting PHP memory_limit option" && php_conf_set memory_limit "$PHP_MEMORY_LIMIT"
     ! is_empty_value "$PHP_POST_MAX_SIZE" && info "Setting PHP post_max_size option" && php_conf_set post_max_size "$PHP_POST_MAX_SIZE"
     ! is_empty_value "$PHP_UPLOAD_MAX_FILESIZE" && info "Setting PHP upload_max_filesize option" && php_conf_set upload_max_filesize "$PHP_UPLOAD_MAX_FILESIZE"


### PR DESCRIPTION
Just fixing max_input_vars because it was not applied correctly 


**Benefits**

Working max_input_vars with ENV variable

**Possible drawbacks**

No drawbacks

**Applicable issues**

Issue #25 

**Additional information**

No additional information
